### PR TITLE
Use $(file <) instead of $(shell cat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIST ?= fc32
-VERSION := $(shell cat version)
-REL := $(shell cat rel)
+VERSION := $(file <version)
+REL := $(file <rel)
 
 FEDORA_SOURCES := https://src.fedoraproject.org/rpms/xdotool/raw/f$(subst fc,,$(DIST))/f/sources
 SRC_FILE := xdotool-$(VERSION).tar.gz


### PR DESCRIPTION
The former is faster and handles errors (such as permission denied
reading the file) correctly.